### PR TITLE
Add automated sonar-project.properties writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ resource_types:
 
 * `repository`: *Required.* BitBucket repository.
 
-* `git`: *Required.* configuration is based on the [Git resource](https://github.com/concourse/git-resource). The branch configuration from the original resource is ignored. 
+* `git`: *Required.* configuration is based on the [Git resource](https://github.com/concourse/git-resource). The branch configuration from the original resource is ignored.
 
 
 ### Example
@@ -109,3 +109,17 @@ Update the build status of pull request with desired state.
 
 * `description`: *Optional.* Description of the build result.
 
+#### Sonar
+
+Just after cloning the repository with `in`, there is a check for an existing `sonar-project.properties`
+file on the root. If the file exists it has appended automatically 3 settings:
+
+```
+sonar.pullrequest.branch={PR_BRANCH}
+sonar.pullrequest.key={PR_ID}
+sonar.pullrequest.base={PR_TARGET_BRANCH}
+```
+
+You just have to execute, whenever you want `sonar-scanner` from the same root of the repository, to add
+the PR check to your sonar. Of course, include extra configuration as needed both in `sonar-project.properties`
+or from the commandline.

--- a/src/in.ts
+++ b/src/in.ts
@@ -3,6 +3,7 @@ import { ConcourseRequest, SourceConfig, Version, ConcourseResponse, PullRequest
 import { BitBucketClient, PullRequest, PullRequestResponse } from './bitbucket';
 import { execFile } from 'child_process';
 import { Execute } from './exec';
+import { SonarProjectWriter } from './sonar-project';
 
 interface GitResourcePayload {
     source: {
@@ -92,6 +93,9 @@ export class InCommand {
                 { name: 'pullrequest updated', value: pr.updated_on },
             ],
         };
+
+        const sonarProjectWriter = new SonarProjectWriter(this._logger, pr, version);
+        await sonarProjectWriter.write(destination);
         return concourseResponse;
     }
 }

--- a/src/sonar-project.ts
+++ b/src/sonar-project.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import { Logger } from './logger';
+import { PullRequestResponse } from './bitbucket';
+import { Version } from './concourse';
+
+export interface SonarConfiguration {
+  id: string;
+  branch: string;
+  base: string;
+}
+
+export class SonarProjectWriter{
+  private _logger: Logger;
+  private _pr: PullRequestResponse;
+  private _version: Version;
+  private _file: string;
+
+  constructor(logger: Logger, pr: PullRequestResponse, version: Version) {
+    this._logger = logger;
+    this._pr = pr;
+    this._version = version;
+    this._file = 'sonar-project.properties';
+  }
+
+  async write(repoPath: string) {
+    try {
+      const filePath = `${repoPath}/${this._file}`;
+      await fs.promises.access(filePath);
+
+      const sonarConf: SonarConfiguration = this.getSonarData();
+      const stream = fs.createWriteStream(filePath, {flags:'a'});
+      stream.write(`sonar.pullrequest.branch=${sonarConf.branch}\n`);
+      stream.write(`sonar.pullrequest.key=${sonarConf.id}\n`);
+      stream.write(`sonar.pullrequest.base=${sonarConf.base}\n`);
+      stream.end();
+    } catch (error) {
+      this._logger.info('The file sonar-project.properties does not exists or is not writable');
+    }
+  }
+
+  private getSonarData(): SonarConfiguration {
+    return {
+      id: this._pr.id,
+      branch: this._version.branch,
+      base: this._pr.destination.branch.name,
+    }
+  }
+}

--- a/src/sonar-project.ts
+++ b/src/sonar-project.ts
@@ -4,45 +4,45 @@ import { PullRequestResponse } from './bitbucket';
 import { Version } from './concourse';
 
 export interface SonarConfiguration {
-  id: string;
-  branch: string;
-  base: string;
+    id: string;
+    branch: string;
+    base: string;
 }
 
 export class SonarProjectWriter{
-  private _logger: Logger;
-  private _pr: PullRequestResponse;
-  private _version: Version;
-  private _file: string;
+    private _logger: Logger;
+    private _pr: PullRequestResponse;
+    private _version: Version;
+    private _file: string;
 
-  constructor(logger: Logger, pr: PullRequestResponse, version: Version) {
-    this._logger = logger;
-    this._pr = pr;
-    this._version = version;
-    this._file = 'sonar-project.properties';
-  }
-
-  async write(repoPath: string) {
-    try {
-      const filePath = `${repoPath}/${this._file}`;
-      await fs.promises.access(filePath);
-
-      const sonarConf: SonarConfiguration = this.getSonarData();
-      const stream = fs.createWriteStream(filePath, {flags:'a'});
-      stream.write(`sonar.pullrequest.branch=${sonarConf.branch}\n`);
-      stream.write(`sonar.pullrequest.key=${sonarConf.id}\n`);
-      stream.write(`sonar.pullrequest.base=${sonarConf.base}\n`);
-      stream.end();
-    } catch (error) {
-      this._logger.info('The file sonar-project.properties does not exists or is not writable');
+    constructor(logger: Logger, pr: PullRequestResponse, version: Version) {
+        this._logger = logger;
+        this._pr = pr;
+        this._version = version;
+        this._file = 'sonar-project.properties';
     }
-  }
 
-  private getSonarData(): SonarConfiguration {
-    return {
-      id: this._pr.id,
-      branch: this._version.branch,
-      base: this._pr.destination.branch.name,
+    async write(repoPath: string) {
+        try {
+            const filePath = `${repoPath}/${this._file}`;
+            await fs.promises.access(filePath);
+
+            const sonarConf: SonarConfiguration = this.getSonarData();
+            const stream = fs.createWriteStream(filePath, {flags: 'a'});
+            stream.write(`sonar.pullrequest.branch=${sonarConf.branch}\n`);
+            stream.write(`sonar.pullrequest.key=${sonarConf.id}\n`);
+            stream.write(`sonar.pullrequest.base=${sonarConf.base}\n`);
+            stream.end();
+        } catch (error) {
+            this._logger.info('The file sonar-project.properties does not exists or is not writable');
+        }
     }
-  }
+
+    private getSonarData(): SonarConfiguration {
+        return {
+            id: this._pr.id,
+            branch: this._version.branch,
+            base: this._pr.destination.branch.name,
+        };
+    }
 }


### PR DESCRIPTION
Just after cloning the repository with `in`, there is a check for an existing `sonar-project.properties` file at the root. If the file exists it has appended automatically 3 settings:

```
sonar.pullrequest.branch={PR_BRANCH}
sonar.pullrequest.key={PR_ID}
sonar.pullrequest.base={PR_TARGET_BRANCH}
```

You just have to execute, whenever you want `sonar-scanner` from the same root of the repository, to add the PR check to your sonar. Of course, include extra configuration as needed both to `sonar-project.properties` or to the commandline.